### PR TITLE
Support DIDCommV1 legacy service

### DIFF
--- a/Tests/PeerDIDTests/CreatePeerDIDAlgo2Tests.swift
+++ b/Tests/PeerDIDTests/CreatePeerDIDAlgo2Tests.swift
@@ -68,7 +68,7 @@ final class CreatePeerDIDAlgo2Tests: XCTestCase {
         id: "test",
         type: "DIDCommMessaging",
         serviceEndpoint: AnyCodable(
-            dictionaryLiteral: ("uri","https://example.com/endpoint"), ("routing_keys", ["did:example:somemediator#somekey"]))
+            dictionaryLiteral: ("uri","https://example.com/endpoint"), ("routingKeys", ["did:example:somemediator#somekey"]))
     )
     
     func testCreatePeerDIDAlgo2Base58() throws {

--- a/Tests/PeerDIDTests/CreatePeerDIDAlgo2Tests.swift
+++ b/Tests/PeerDIDTests/CreatePeerDIDAlgo2Tests.swift
@@ -86,6 +86,22 @@ final class CreatePeerDIDAlgo2Tests: XCTestCase {
         XCTAssertTrue(peerDID.algo2Service.contains("eyJzIjp7InIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwidXJpIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9LCJ0IjoiZG0ifQ"))
     }
     
+    func testCreatePeerDIDAlgo2Legacy() throws {
+        let peerDID = try PeerDIDHelper.createAlgo2(
+            authenticationKeys: [valid_ed25519_key1_base58, valid_ed25519_key2_base58],
+            agreementKeys: [valid_x25519_key_base58],
+            services: [validService],
+            recipientKeys: [[]]
+        )
+        
+        XCTAssertEqual("did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il0sInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50IiwidCI6ImRtIn0", peerDID.string)
+        
+        XCTAssertTrue(peerDID.algo2KeyAgreementKeys.contains("z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc"))
+        XCTAssertTrue(peerDID.algo2AuthenticationKeys.contains("z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"))
+        XCTAssertTrue(peerDID.algo2AuthenticationKeys.contains("z6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg"))
+        XCTAssertTrue(peerDID.algo2Service.contains("eyJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il0sInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50IiwidCI6ImRtIn0"))
+    }
+
     func testCreatePeerDIDAlgo2Multibase() throws {
         let peerDID = try PeerDIDHelper.createAlgo2(
             authenticationKeys: [valid_ed25519_key1_multibase, valid_ed25519_key2_multibase],

--- a/Tests/PeerDIDTests/EncodeServiceTests.swift
+++ b/Tests/PeerDIDTests/EncodeServiceTests.swift
@@ -32,14 +32,29 @@ final class EncodeEcnumbasisTests: XCTestCase {
                 dictionaryLiteral: ("uri","https://example.com/endpoint"), ("routingKeys", ["did:example:somemediator#somekey"]), ("accept", ["didcomm/v2", "didcomm/aip2;env=rfc587"]))
         )
         
-        let expect = "SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0"
+        let expect = "SeyJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il0sInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50IiwidCI6ImRtIn0"
+        
+        XCTAssertEqual(expect, try PeerDIDHelper().encodePeerDIDServices(service: service, recipientKeys: []))
+    }
+
+    func testEncodeToLegacyServiceNoAccept() throws {
+        let service = DIDDocument.Service(
+            id: "test",
+            type: "DIDCommMessaging",
+            serviceEndpoint: AnyCodable(
+                dictionaryLiteral: ("uri","https://example.com/endpoint"), ("routingKeys", ["did:example:somemediator#somekey"]))
+            )
+        
+        let expect = "SeyJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il0sInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50IiwidCI6ImRtIn0"
         
         XCTAssertEqual(expect, try PeerDIDHelper().encodePeerDIDServices(service: service, recipientKeys: []))
     }
 
     func testDecodeService() throws {
         let did = "did:test:abc"
-        let service = "eyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0"
+        let legacyService = "eyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0"
+        let legacyServiceSorted = "eyJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il0sInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50IiwidCI6ImRtIn0"
+        let service = "eyJzIjp7ImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il0sInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwidXJpIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9LCJ0IjoiZG0ifQ"
         
         let expected = DIDDocument.Service(
             id: "did:test:abc#didcommmessaging-1",
@@ -49,6 +64,8 @@ final class EncodeEcnumbasisTests: XCTestCase {
         )
         
         XCTAssertEqual(expected, try PeerDIDHelper().decodedPeerDIDService(did: did, serviceString: service, index: 0))
+        XCTAssertEqual(expected, try PeerDIDHelper().decodedPeerDIDService(did: did, serviceString: legacyService, index: 0))
+        XCTAssertEqual(expected, try PeerDIDHelper().decodedPeerDIDService(did: did, serviceString: legacyServiceSorted, index: 0))
     }
 }
 

--- a/Tests/PeerDIDTests/EncodeServiceTests.swift
+++ b/Tests/PeerDIDTests/EncodeServiceTests.swift
@@ -16,14 +16,27 @@ final class EncodeEcnumbasisTests: XCTestCase {
             id: "did:test:abc#didcommmessaging-1",
             type: "DIDCommMessaging",
             serviceEndpoint: AnyCodable(
-                dictionaryLiteral: ("uri","https://example.com/endpoint"), ("routing_keys", ["did:example:somemediator#somekey"]), ("accept", ["didcomm/v2", "didcomm/aip2;env=rfc587"]))
+                dictionaryLiteral: ("uri","https://example.com/endpoint"), ("routingKeys", ["did:example:somemediator#somekey"]), ("accept", ["didcomm/v2", "didcomm/aip2;env=rfc587"]))
         )
         
         let expect = "SeyJzIjp7ImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il0sInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwidXJpIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9LCJ0IjoiZG0ifQ"
         
         XCTAssertEqual(expect, try PeerDIDHelper().encodePeerDIDServices(service: service))
     }
-    
+
+    func testEncodeToLegacyService() throws {
+        let service = DIDDocument.Service(
+            id: "did:test:abc#didcommmessaging-1",
+            type: "DIDCommMessaging",
+            serviceEndpoint: AnyCodable(
+                dictionaryLiteral: ("uri","https://example.com/endpoint"), ("routingKeys", ["did:example:somemediator#somekey"]), ("accept", ["didcomm/v2", "didcomm/aip2;env=rfc587"]))
+        )
+        
+        let expect = "SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0"
+        
+        XCTAssertEqual(expect, try PeerDIDHelper().encodePeerDIDServices(service: service, recipientKeys: []))
+    }
+
     func testDecodeService() throws {
         let did = "did:test:abc"
         let service = "eyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0"
@@ -32,7 +45,7 @@ final class EncodeEcnumbasisTests: XCTestCase {
             id: "did:test:abc#didcommmessaging-1",
             type: "DIDCommMessaging",
             serviceEndpoint: AnyCodable(
-                dictionaryLiteral: ("uri","https://example.com/endpoint"), ("routing_keys", ["did:example:somemediator#somekey"]), ("accept", ["didcomm/v2", "didcomm/aip2;env=rfc587"]))
+                dictionaryLiteral: ("uri","https://example.com/endpoint"), ("routingKeys", ["did:example:somemediator#somekey"]), ("accept", ["didcomm/v2", "didcomm/aip2;env=rfc587"]))
         )
         
         XCTAssertEqual(expected, try PeerDIDHelper().decodedPeerDIDService(did: did, serviceString: service, index: 0))
@@ -51,6 +64,6 @@ extension DIDDocument.Service: Equatable {
         lhs.type == rhs.type &&
         (lhsS["uri"] as! String) == (rhsS["uri"] as! String) &&
         (lhsS["accept"] as? [String]) == (rhsS["accept"] as? [String]) &&
-        (lhsS["routing_keys"]  as? [String]) == (rhsS["routing_keys"] as? [String])
+        (lhsS["routingKeys"]  as? [String]) == (rhsS["routingKeys"] as? [String])
     }
 }


### PR DESCRIPTION
`PeerDIDHelper` already had `PeerDIDServiceLegacy` which was the [service type](https://github.com/hyperledger/aries-rfcs/blob/main/features/0067-didcomm-diddoc-conventions/README.md#service-conventions) of DIDCommV1, but `recipientKeys` property was missing.

This change allows `PeerDIDHelper` to create a numAlgo 2 peer-did with the legacy service. This has been tested with the Credo-ts to do did-exchange protocol which exchanges numAlgo 2 peer-dids.