### PR TITLE
Raised did-core minimum version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/swift-libp2p/swift-multibase.git", .upToNextMajor(from: "0.0.1")),
         .package(url: "https://github.com/swift-libp2p/swift-bases.git", .upToNextMajor(from: "0.0.3")),
-        .package(url: "https://github.com/beatt83/didcore-swift.git", .upToNextMinor(from: "2.0.0"))
+        .package(url: "https://github.com/beatt83/didcore-swift.git", .upToNextMinor(from: "2.0.2"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
The minimum version of did-core should be 2.0.2, not 2.0.0, to ensure compatibility