### PR TITLE
Raise didcore-swift minimum version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/swift-libp2p/swift-multibase.git", .upToNextMajor(from: "0.0.1")),
         .package(url: "https://github.com/swift-libp2p/swift-bases.git", .upToNextMajor(from: "0.0.3")),
-        .package(url: "https://github.com/beatt83/didcore-swift.git", .upToNextMinor(from: "2.0.0"))
+        .package(url: "https://github.com/beatt83/didcore-swift.git", .upToNextMinor(from: "2.0.2"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
Raise didcore-swift minimum version to 2.0.2. API compatibility issues with 2.0.1 and below.